### PR TITLE
Options and reconnect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -280,6 +280,9 @@ export class WikimediaStream extends EventEmitter {
      * Stop listening to the stream.
      */
     public close(): void {
+        clearInterval(this.openCheckInterval);
+        this.openCheckInterval = null;
+
         this.eventSource.close();
         this.eventSource = null;
         this.emit("close");

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,10 @@ export class WikimediaStream extends EventEmitter {
      * Creates a new Wikimedia RecentChanges listener.
      * @param streams
      */
-    public constructor(streams: WikimediaEventStream | WikimediaEventStream[]) {
+    public constructor(
+        streams: WikimediaEventStream | WikimediaEventStream[],
+        options: EventSourceInitDict = {}
+    ) {
         super();
 
         // Validate stream type
@@ -226,7 +229,7 @@ export class WikimediaStream extends EventEmitter {
         }
         this.streams = specificStreams;
 
-        this.open();
+        this.open(options);
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,24 +239,32 @@ export class WikimediaStream extends EventEmitter {
         if (this.eventSource && this.eventSource.readyState !== this.eventSource.CLOSED)
             this.close();
 
-        // Send Last-Event-ID to pick up from cancels.
-        this.eventSource = new EventSource(`https://stream.wikimedia.org/v2/stream/${
-            this.streams.join(",")
-        }`, Object.assign(options, {
-            headers: this.lastEventId != null ? {
-                "Last-Event-ID": this.lastEventId,
-                ...(options.headers ?? {})
-            } : (options.headers ?? {})
-        }));
+        // Send Last-Event-ID to pick up from cancels, overriding the
+        // Last-Event-ID header provided in options.
+
+        options.headers = this.lastEventId != null ? {
+            ...(options.headers ?? {}),
+            "Last-Event-ID": this.lastEventId
+        } : (options.headers ?? {});
+
+        this.eventSource = new EventSource(
+            `https://stream.wikimedia.org/v2/stream/${this.streams.join(",")}`,
+             options
+        );
 
         this.eventSource.addEventListener("open", () => {
             this.emit("open");
         });
+
         this.eventSource.addEventListener("error", (e: ErrorEvent) => {
             this.emit("error", e);
             if (this.eventSource.readyState !== this.eventSource.OPEN) {
-                this.open();
+                this.open(options);
             }
+        });
+
+        this.eventSource.addEventListener("close", () => {
+            this.open(options);
         });
 
         this.eventSource.addEventListener("message", async (event: MessageEvent) => {
@@ -274,7 +282,7 @@ export class WikimediaStream extends EventEmitter {
 
         this.openCheckInterval = setInterval(() => {
             if (this.eventSource.readyState !== this.eventSource.OPEN) {
-                this.open();
+                this.open(options);
             }
         }, 1000);
     }


### PR DESCRIPTION
This has a couple bug fixes and adds an `options` argument to the `WikimediaStream` constructor. I was looking for a way to start a stream from a previous point in time and use a custom User-Agent. I believe this could already be done by creating the `WikimediaStream` object and then manually invoking the `open(options)` method, but allowing that behavior to be provided in the constructor gives you control of the first request made, and streamlines things into just the constructor.

Example of usage:
```Javascript
const stream = new WikimediaStream("recentchange", {
  headers: {
    'User-Agent': 'custom-user-agent',
    'Last-Event-ID': lastEvent
  }
});
```
Using this, one could also get access to the `Since` header of the API.

In terms of bug fixes, if custom options or headers were provided to `WikimediaStream.open(options)`, and the event handlers inside attempted to reconnect, the options would not persist into those calls. An example of what this does, is that a custom user agent would be lost on each new connection after the first. This is solved by relaying `options` arguments between `open()` calls, and, in the event that `Last-Event-ID` was defined in the headers but `open()` has created another connection, prioritizing the `Last-Event-ID` stored in `WikimediaStream.lastEventId` over the one in `options.headers`.

There was also an error after the tests finished running, which was occurring because `WikimediaStream.openCheckInterval` was accessing attributes of `eventSource` after it had been nulled out in `WikimediaStream.close()`.