### PR TITLE
Add `mediawiki.revision-tags-change` event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
             },
             "devDependencies": {
                 "@types/eventsource": "^1.1.8",
-                "@types/jest": "^26.0.24",
+                "@types/jest": "^27.5.1",
                 "@types/node": "^16.11.26",
                 "jest": "^27.5.1",
                 "ts-jest": "^27.1.3",
@@ -984,13 +984,13 @@
             }
         },
         "node_modules/@types/jest": {
-            "version": "26.0.24",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
-            "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
+            "version": "27.5.2",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+            "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
             "dev": true,
             "dependencies": {
-                "jest-diff": "^26.0.0",
-                "pretty-format": "^26.0.0"
+                "jest-matcher-utils": "^27.0.0",
+                "pretty-format": "^27.0.0"
             }
         },
         "node_modules/@types/node": {
@@ -1587,15 +1587,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/diff-sequences": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-            "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.14.2"
-            }
-        },
         "node_modules/domexception": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -1722,9 +1713,9 @@
             }
         },
         "node_modules/eventsource": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.0.tgz",
-            "integrity": "sha512-U9TI2qLWwedwiDLCbSUoSAPHGK2P7nT6/f25wBzMy9tWOKgFoNY4n+GYCPCYg3sGKrIoCmpChJoO3KKymcLo8A==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+            "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
             "engines": {
                 "node": ">=12.0.0"
             }
@@ -2277,32 +2268,6 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
-        "node_modules/jest-circus/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-circus/node_modules/pretty-format": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
         "node_modules/jest-cli": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.5.1.tgz",
@@ -2380,56 +2345,6 @@
                 }
             }
         },
-        "node_modules/jest-config/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-config/node_modules/pretty-format": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
-        "node_modules/jest-diff": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
-            "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "diff-sequences": "^26.6.2",
-                "jest-get-type": "^26.3.0",
-                "pretty-format": "^26.6.2"
-            },
-            "engines": {
-                "node": ">= 10.14.2"
-            }
-        },
-        "node_modules/jest-diff/node_modules/jest-get-type": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-            "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.14.2"
-            }
-        },
         "node_modules/jest-docblock": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.5.1.tgz",
@@ -2453,32 +2368,6 @@
                 "jest-get-type": "^27.5.1",
                 "jest-util": "^27.5.1",
                 "pretty-format": "^27.5.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
-        "node_modules/jest-each/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-each/node_modules/pretty-format": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
             },
             "engines": {
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -2582,32 +2471,6 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
-        "node_modules/jest-jasmine2/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-jasmine2/node_modules/pretty-format": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
         "node_modules/jest-leak-detector": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.5.1.tgz",
@@ -2616,32 +2479,6 @@
             "dependencies": {
                 "jest-get-type": "^27.5.1",
                 "pretty-format": "^27.5.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
-        "node_modules/jest-leak-detector/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-leak-detector/node_modules/pretty-format": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
             },
             "engines": {
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -2660,18 +2497,6 @@
             },
             "engines": {
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
-        "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/jest-matcher-utils/node_modules/diff-sequences": {
@@ -2698,20 +2523,6 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
-        "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
         "node_modules/jest-message-util": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.5.1.tgz",
@@ -2727,32 +2538,6 @@
                 "pretty-format": "^27.5.1",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.3"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
-        "node_modules/jest-message-util/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-message-util/node_modules/pretty-format": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
             },
             "engines": {
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -2943,18 +2728,6 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
-        "node_modules/jest-snapshot/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/jest-snapshot/node_modules/diff-sequences": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
@@ -2974,20 +2747,6 @@
                 "diff-sequences": "^27.5.1",
                 "jest-get-type": "^27.5.1",
                 "pretty-format": "^27.5.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
-        "node_modules/jest-snapshot/node_modules/pretty-format": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
             },
             "engines": {
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -3042,18 +2801,6 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
-        "node_modules/jest-validate/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/jest-validate/node_modules/camelcase": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -3064,20 +2811,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/jest-validate/node_modules/pretty-format": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
         "node_modules/jest-watcher": {
@@ -3629,43 +3362,29 @@
             }
         },
         "node_modules/pretty-format": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-            "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^26.6.2",
-                "ansi-regex": "^5.0.0",
-                "ansi-styles": "^4.0.0",
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
                 "react-is": "^17.0.1"
             },
             "engines": {
-                "node": ">= 10"
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
-        "node_modules/pretty-format/node_modules/@jest/types": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-            "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
-            "dependencies": {
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^15.0.0",
-                "chalk": "^4.0.0"
-            },
             "engines": {
-                "node": ">= 10.14.2"
-            }
-        },
-        "node_modules/pretty-format/node_modules/@types/yargs": {
-            "version": "15.0.14",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-            "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/prompts": {
@@ -5198,13 +4917,13 @@
             }
         },
         "@types/jest": {
-            "version": "26.0.24",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
-            "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
+            "version": "27.5.2",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+            "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
             "dev": true,
             "requires": {
-                "jest-diff": "^26.0.0",
-                "pretty-format": "^26.0.0"
+                "jest-matcher-utils": "^27.0.0",
+                "pretty-format": "^27.0.0"
             }
         },
         "@types/node": {
@@ -5671,12 +5390,6 @@
             "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
             "dev": true
         },
-        "diff-sequences": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-            "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
-            "dev": true
-        },
         "domexception": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -5765,9 +5478,9 @@
             "dev": true
         },
         "eventsource": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.0.tgz",
-            "integrity": "sha512-U9TI2qLWwedwiDLCbSUoSAPHGK2P7nT6/f25wBzMy9tWOKgFoNY4n+GYCPCYg3sGKrIoCmpChJoO3KKymcLo8A=="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+            "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="
         },
         "execa": {
             "version": "5.1.1",
@@ -6177,25 +5890,6 @@
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.3",
                 "throat": "^6.0.1"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "27.5.1",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-                    "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.1",
-                        "ansi-styles": "^5.0.0",
-                        "react-is": "^17.0.1"
-                    }
-                }
             }
         },
         "jest-cli": {
@@ -6248,45 +5942,6 @@
                 "pretty-format": "^27.5.1",
                 "slash": "^3.0.0",
                 "strip-json-comments": "^3.1.1"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "27.5.1",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-                    "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.1",
-                        "ansi-styles": "^5.0.0",
-                        "react-is": "^17.0.1"
-                    }
-                }
-            }
-        },
-        "jest-diff": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
-            "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
-            "dev": true,
-            "requires": {
-                "chalk": "^4.0.0",
-                "diff-sequences": "^26.6.2",
-                "jest-get-type": "^26.3.0",
-                "pretty-format": "^26.6.2"
-            },
-            "dependencies": {
-                "jest-get-type": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-                    "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-                    "dev": true
-                }
             }
         },
         "jest-docblock": {
@@ -6309,25 +5964,6 @@
                 "jest-get-type": "^27.5.1",
                 "jest-util": "^27.5.1",
                 "pretty-format": "^27.5.1"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "27.5.1",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-                    "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.1",
-                        "ansi-styles": "^5.0.0",
-                        "react-is": "^17.0.1"
-                    }
-                }
             }
         },
         "jest-environment-jsdom": {
@@ -6409,25 +6045,6 @@
                 "jest-util": "^27.5.1",
                 "pretty-format": "^27.5.1",
                 "throat": "^6.0.1"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "27.5.1",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-                    "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.1",
-                        "ansi-styles": "^5.0.0",
-                        "react-is": "^17.0.1"
-                    }
-                }
             }
         },
         "jest-leak-detector": {
@@ -6438,25 +6055,6 @@
             "requires": {
                 "jest-get-type": "^27.5.1",
                 "pretty-format": "^27.5.1"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "27.5.1",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-                    "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.1",
-                        "ansi-styles": "^5.0.0",
-                        "react-is": "^17.0.1"
-                    }
-                }
             }
         },
         "jest-matcher-utils": {
@@ -6471,12 +6069,6 @@
                 "pretty-format": "^27.5.1"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-                    "dev": true
-                },
                 "diff-sequences": {
                     "version": "27.5.1",
                     "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
@@ -6493,17 +6085,6 @@
                         "diff-sequences": "^27.5.1",
                         "jest-get-type": "^27.5.1",
                         "pretty-format": "^27.5.1"
-                    }
-                },
-                "pretty-format": {
-                    "version": "27.5.1",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-                    "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.1",
-                        "ansi-styles": "^5.0.0",
-                        "react-is": "^17.0.1"
                     }
                 }
             }
@@ -6523,25 +6104,6 @@
                 "pretty-format": "^27.5.1",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.3"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "27.5.1",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-                    "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.1",
-                        "ansi-styles": "^5.0.0",
-                        "react-is": "^17.0.1"
-                    }
-                }
             }
         },
         "jest-mock": {
@@ -6695,12 +6257,6 @@
                 "semver": "^7.3.2"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-                    "dev": true
-                },
                 "diff-sequences": {
                     "version": "27.5.1",
                     "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
@@ -6717,17 +6273,6 @@
                         "diff-sequences": "^27.5.1",
                         "jest-get-type": "^27.5.1",
                         "pretty-format": "^27.5.1"
-                    }
-                },
-                "pretty-format": {
-                    "version": "27.5.1",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-                    "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.1",
-                        "ansi-styles": "^5.0.0",
-                        "react-is": "^17.0.1"
                     }
                 },
                 "semver": {
@@ -6769,28 +6314,11 @@
                 "pretty-format": "^27.5.1"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-                    "dev": true
-                },
                 "camelcase": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
                     "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
                     "dev": true
-                },
-                "pretty-format": {
-                    "version": "27.5.1",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-                    "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.1",
-                        "ansi-styles": "^5.0.0",
-                        "react-is": "^17.0.1"
-                    }
                 }
             }
         },
@@ -7214,38 +6742,21 @@
             "dev": true
         },
         "pretty-format": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-            "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.6.2",
-                "ansi-regex": "^5.0.0",
-                "ansi-styles": "^4.0.0",
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
                 "react-is": "^17.0.1"
             },
             "dependencies": {
-                "@jest/types": {
-                    "version": "26.6.2",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-                    "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/yargs": {
-                    "version": "15.0.14",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-                    "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/yargs-parser": "*"
-                    }
+                "ansi-styles": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+                    "dev": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "homepage": "https://github.com/ChlodAlejandro/wikimedia-streams#readme",
     "devDependencies": {
         "@types/eventsource": "^1.1.8",
-        "@types/jest": "^26.0.24",
+        "@types/jest": "^27.5.1",
         "@types/node": "^16.11.26",
         "jest": "^27.5.1",
         "ts-jest": "^27.1.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "events";
+import {EventEmitter} from "events";
 import EventSource, {EventSourceInitDict} from "eventsource";
 import WikimediaEventBase from "./streams/EventStream";
 import type MediaWikiRevisionCreateEvent from "./streams/MediaWikiRevisionCreateEvent";
@@ -12,6 +12,7 @@ import type MediaWikiRevisionScoreEvent from "./streams/MediaWikiRevisionScoreEv
 import type MediaWikiRevisionVisibilityChangeEvent from "./streams/MediaWikiRevisionVisibilityChangeEvent";
 import type EventGateTestEvent from "./streams/EventGateTestEvent";
 import path from "path";
+import MediaWikiRevisionTagsChangeEvent from "./streams/MediaWikiRevisionTagsChangeEvent";
 
 /**
  * The list of Wikimedia EventStreams types, excluding aliases (found in
@@ -30,6 +31,7 @@ export const WikimediaEventStreams = <const>[
     "mediawiki.recentchange",
     "mediawiki.revision-create",
     "mediawiki.revision-score",
+	"mediawiki.revision-tags-change",
     "mediawiki.revision-visibility-change"
 ];
 
@@ -77,6 +79,7 @@ type WikimediaEventStreamEventTypes = {
     "revision-create": MediaWikiRevisionCreateEvent,
     "mediawiki.revision-score": MediaWikiRevisionScoreEvent,
     "revision-score": MediaWikiRevisionScoreEvent,
+	"mediawiki.revision-tags-change": MediaWikiRevisionTagsChangeEvent,
     "mediawiki.revision-visibility-change": MediaWikiRevisionVisibilityChangeEvent
 }
 

--- a/src/streams/EventStream.ts
+++ b/src/streams/EventStream.ts
@@ -14,6 +14,7 @@ import MediaWikiRecentChangeEvent from "./MediaWikiRecentChangeEvent";
 import MediaWikiRevisionCreateEvent from "./MediaWikiRevisionCreateEvent";
 import MediaWikiRevisionScoreEvent from "./MediaWikiRevisionScoreEvent";
 import MediaWikiRevisionVisibilityChangeEvent from "./MediaWikiRevisionVisibilityChangeEvent";
+import MediaWikiRevisionTagsChangeEvent from "./MediaWikiRevisionTagsChangeEvent";
 
 interface WikimediaEventMeta {
 
@@ -66,6 +67,7 @@ type WikimediaEvent =
     | MediaWikiRecentChangeEvent
     | MediaWikiRevisionCreateEvent
     | MediaWikiRevisionScoreEvent
+	| MediaWikiRevisionTagsChangeEvent
     | MediaWikiRevisionVisibilityChangeEvent;
 
 export default WikimediaEvent;

--- a/src/streams/MediaWikiRevisionTagsChangeEvent.ts
+++ b/src/streams/MediaWikiRevisionTagsChangeEvent.ts
@@ -1,0 +1,30 @@
+/*
+ * Documentation for the schema was derived from <https://stream.wikimedia.org/?doc>,
+ * which is licensed under the Apache License 2.0.
+ */
+
+import {MediaWikiEvent} from "./EventStream";
+import Page from "./common/Page";
+import Comment from "./common/Comment";
+import Revision from "./common/Revision";
+
+/** Represents a MW Revision Tags Change event. */
+export default interface MediaWikiRevisionTagsChangeEvent extends
+    MediaWikiEvent, Page, Comment, Revision {
+
+	/**
+	 * An array of all the tags for this MediaWiki revision.
+	 */
+    tags: string[];
+	/**
+	 * The prior state of this MediaWiki revision. Includes tags that were already
+	 * part of the revision prior to this event.
+	 */
+	prior_state: {
+		/**
+		 * An array of the tags for this MediaWiki revision prior to this event.
+		 */
+		tags: string[];
+	};
+
+}


### PR DESCRIPTION
Solves #6. Adds in the new `mediawiki.revision-tags-change` event. Example provided below.
```json
{
    "$schema": "/mediawiki/revision/tags-change/1.0.0",
    "meta": {
        "uri": "https://en.wikipedia.org/wiki/Sweetheart_cake",
        "request_id": "d38817bb-2d01-402b-b1f3-37c4132959e0",
        "id": "b0e2b95d-69bf-4897-a2f6-689aa1a572c9",
        "dt": "2022-06-15T18:00:16Z",
        "domain": "en.wikipedia.org",
        "stream": "mediawiki.revision-tags-change",
        "topic": "eqiad.mediawiki.revision-tags-change",
        "partition": 0,
        "offset": 866815954
    },
    "database": "enwiki",
    "page_id": 501632,
    "page_title": "Sweetheart_cake",
    "page_namespace": 0,
    "rev_id": 1093297086,
    "rev_timestamp": "2022-06-15T18:00:13Z",
    "rev_sha1": "2ircnjmlycpa1zafigfg8f5t8phxow8",
    "rev_minor_edit": false,
    "rev_len": 6600,
    "rev_content_model": "wikitext",
    "rev_content_format": "text/x-wiki",
    "performer": {
        "user_text": "80.5.216.57",
        "user_groups": [
            "*"
        ],
        "user_is_bot": false
    },
    "page_is_redirect": false,
    "comment": "/* Variants */Replace dead link with internet archive link, and move it to the location of the actual claim it supports",
    "parsedcomment": "<span dir=\"auto\"><span class=\"autocomment\">Variants: </span>Replace dead link with internet archive link, and move it to the location of the actual claim it supports</span>",
    "rev_parent_id": 1091009264,
    "tags": [
        "mobile web edit",
        "mobile edit"
    ],
    "prior_state": {
        "tags": [
            
        ]
    }
}
```

Type checks and integration tests to be added in a later PR (along with type checks/integration tests for other event streams that don't have it yet).