### PR TITLE
Increase CI stability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "typescript": "^4.6.2"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.15.0"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/tests/MediaWikiStandardizedStreamTest.ts
+++ b/tests/MediaWikiStandardizedStreamTest.ts
@@ -31,10 +31,6 @@ beforeAll( () => {
 	expect( WikimediaStream.VERSION ).toBe( version );
 } );
 
-beforeEach( ( doneFn ) => {
-	setTimeout( doneFn, 2000 );
-} );
-
 function generateStream( topic: WikimediaEventStream ): Promise<WikimediaStream> {
 	return new Promise<WikimediaStream>( res => {
 		const stream = new WikimediaStream(

--- a/tests/WikimediaStreamTest.ts
+++ b/tests/WikimediaStreamTest.ts
@@ -100,7 +100,7 @@ describe( 'WikimediaStream tests', () => {
 			expect(
 				Math.abs( new Date( edit.meta.dt ).getTime() -
 				new Date( referenceEvent.meta.dt ).getTime() )
-			).toBeLessThan( 1e3 );
+			).toBeLessThanOrEqual( 3e3 );
 			stream2.close();
 		} );
 		await stream2.open();

--- a/tests/WikimediaStreamTest.ts
+++ b/tests/WikimediaStreamTest.ts
@@ -70,7 +70,7 @@ describe( 'WikimediaStream tests', () => {
 			} ],
 			autoStart: false
 		} );
-		stream2.once( 'recentchange', ( edit ) => {
+		stream2.on( 'recentchange', ( edit ) => {
 			if ( edit.meta.topic !== referenceEvent.meta.topic ) {
 				// skip events that aren't from the right datacenter
 				return;
@@ -102,8 +102,10 @@ describe( 'WikimediaStream tests', () => {
 		} );
 		stream2.once( 'recentchange', ( edit ) => {
 			expect(
-				Math.abs( new Date( edit.meta.dt ).getTime() - new Date( referenceEvent.meta.dt ).getTime() )
-			).toBeLessThan( 3e3 );
+				new Date( edit.meta.dt ).getTime()
+			).toBeCloseTo(
+				new Date( referenceEvent.meta.dt ).getTime()
+			);
 			stream2.close();
 		} );
 		await stream2.open();
@@ -218,13 +220,11 @@ describe( 'WikimediaStream tests', () => {
 		} );
 		console.log( stream1ReferenceEvent.meta.id );
 		stream2.once( 'recentchange', ( edit ) => {
-			// Repeated testing has proven that picking up from the exact event is
-			// nearly impossible. We'll do a close check instead.
 			console.log( edit.meta.id, '+' );
-			expect(
-				Math.abs( new Date( edit.meta.dt ).getTime() - new Date( stream1ReferenceEvent.meta.dt ).getTime() )
-			).toBeLessThan( 3e3 );
-			stream2.close();
+			if ( edit.meta.id === stream1ReferenceEvent.meta.id ) {
+				expect( edit ).toEqual( stream1ReferenceEvent );
+				stream2.close();
+			}
 		} );
 		expect( stream2.getLastEventId() ).toEqual( referenceLastEventId );
 		await stream2.open();

--- a/tests/WikimediaStreamTest.ts
+++ b/tests/WikimediaStreamTest.ts
@@ -98,10 +98,9 @@ describe( 'WikimediaStream tests', () => {
 		} );
 		stream2.once( 'recentchange', ( edit ) => {
 			expect(
-				new Date( edit.meta.dt ).getTime()
-			).toBeCloseTo(
-				new Date( referenceEvent.meta.dt ).getTime()
-			);
+				Math.abs( new Date( edit.meta.dt ).getTime() -
+				new Date( referenceEvent.meta.dt ).getTime() )
+			).toBeLessThan( 1e3 );
 			stream2.close();
 		} );
 		await stream2.open();
@@ -202,11 +201,8 @@ describe( 'WikimediaStream tests', () => {
 		expect( typeof referenceLastEventId ).toBe( 'string' );
 
 		stream1.once( 'recentchange', ( edit ) => {
-			// conditional statement to avoid race condition
-			if ( !stream1ReferenceEvent ) {
-				stream1ReferenceEvent = edit;
-				referencePostLastEventId = stream1.getLastEventId();
-			}
+			referencePostLastEventId = stream1.getLastEventId();
+			stream1ReferenceEvent = edit;
 			stream1.close();
 		} );
 		await stream1.open();

--- a/tests/WikimediaStreamTest.ts
+++ b/tests/WikimediaStreamTest.ts
@@ -212,16 +212,18 @@ describe( 'WikimediaStream tests', () => {
 			lastEventId: JSON.parse( referenceLastEventId ),
 			autoStart: false
 		} );
-		console.log( JSON.stringify( stream1ReferenceEvent.meta ) );
+		console.log( 1, JSON.stringify( stream1ReferenceEvent.meta ) );
 		stream2.once( 'recentchange', ( edit ) => {
-			console.log( JSON.stringify( edit.meta ), '+' );
+			console.log( 4, JSON.stringify( edit.meta ), '+' );
+			console.log( 5, JSON.stringify( stream1ReferenceEvent ) );
+			console.log( 6, JSON.stringify( edit ), '+' );
 			expect( stream2.getLastEventId() ).toEqual( referencePostLastEventId );
 			expect( edit ).toEqual( stream1ReferenceEvent );
 			stream2.close();
 		} );
 		// getLastEventId() at this point should still return the reference ID.
-		console.log( referenceLastEventId );
-		console.log( stream2.getLastEventId(), '+' );
+		console.log( 2, referenceLastEventId );
+		console.log( 3, stream2.getLastEventId(), '+' );
 		expect( stream2.getLastEventId() ).toEqual( referenceLastEventId );
 		await stream2.open();
 		return Promise.race( [

--- a/tests/WikimediaStreamTest.ts
+++ b/tests/WikimediaStreamTest.ts
@@ -184,7 +184,7 @@ describe( 'WikimediaStream tests', () => {
 	} );
 
 	test( 'fn getLastEventId(): stream is recoverable from last event ID', async () => {
-		expect.assertions( 3 );
+		expect.assertions( 4 );
 		let stream1ReferenceEvent : MediaWikiRecentChangeEvent;
 
 		const stream1 = new WikimediaStream( 'recentchange', {
@@ -198,12 +198,14 @@ describe( 'WikimediaStream tests', () => {
 		await stream1.waitUntilClosed();
 
 		const referenceLastEventId = stream1.getLastEventId();
+		let referencePostLastEventId : string;
 		expect( typeof referenceLastEventId ).toBe( 'string' );
 
 		stream1.once( 'recentchange', ( edit ) => {
 			// conditional statement to avoid race condition
 			if ( !stream1ReferenceEvent ) {
 				stream1ReferenceEvent = edit;
+				referencePostLastEventId = stream1.getLastEventId();
 			}
 			stream1.close();
 		} );
@@ -217,6 +219,7 @@ describe( 'WikimediaStream tests', () => {
 		console.log( JSON.stringify( stream1ReferenceEvent.meta ) );
 		stream2.once( 'recentchange', ( edit ) => {
 			console.log( JSON.stringify( edit.meta ), '+' );
+			expect( stream2.getLastEventId() ).toEqual( referencePostLastEventId );
 			expect( edit ).toEqual( stream1ReferenceEvent );
 			stream2.close();
 		} );

--- a/tests/WikimediaStreamTest.ts
+++ b/tests/WikimediaStreamTest.ts
@@ -219,6 +219,9 @@ describe( 'WikimediaStream tests', () => {
 			expect( edit ).toEqual( stream1ReferenceEvent );
 			stream2.close();
 		} );
+		// getLastEventId() at this point should still return the reference ID.
+		console.log( referenceLastEventId );
+		console.log( stream2.getLastEventId(), '+' );
 		expect( stream2.getLastEventId() ).toEqual( referenceLastEventId );
 		await stream2.open();
 		return Promise.race( [

--- a/tests/WikimediaStreamTest.ts
+++ b/tests/WikimediaStreamTest.ts
@@ -214,13 +214,11 @@ describe( 'WikimediaStream tests', () => {
 			lastEventId: JSON.parse( referenceLastEventId ),
 			autoStart: false
 		} );
-		console.log( stream1ReferenceEvent.meta.id );
+		console.log( JSON.stringify( stream1ReferenceEvent.meta ) );
 		stream2.once( 'recentchange', ( edit ) => {
-			console.log( edit.meta.id, '+' );
-			if ( edit.meta.id === stream1ReferenceEvent.meta.id ) {
-				expect( edit ).toEqual( stream1ReferenceEvent );
-				stream2.close();
-			}
+			console.log( JSON.stringify( edit.meta ), '+' );
+			expect( edit ).toEqual( stream1ReferenceEvent );
+			stream2.close();
 		} );
 		expect( stream2.getLastEventId() ).toEqual( referenceLastEventId );
 		await stream2.open();
@@ -233,16 +231,18 @@ describe( 'WikimediaStream tests', () => {
 	} );
 
 	test( 'fn waitUntilClosed(): waits until closed', async () => {
+		expect.hasAssertions();
 		const stream = new WikimediaStream( 'recentchange' );
 		stream.on( 'open', () => {
 			stream.close();
 		} );
-		return Promise.race( [
+		await Promise.race( [
 			await stream.waitUntilClosed(),
-			new Promise<void>( ( res, rej ) => {
-				setTimeout( rej, 10000 );
+			new Promise<void>( ( res ) => {
+				setTimeout( res, 10000 );
 			} )
 		] );
+		expect( stream.eventSource ).toBeNull();
 	} );
 
 	test( 'fn waitUntilClosed(): returns immediately if already closed', async () => {

--- a/tests/WikimediaStreamTest.ts
+++ b/tests/WikimediaStreamTest.ts
@@ -6,10 +6,6 @@ import MediaWikiRecentChangeEvent from '../src/streams/MediaWikiRecentChangeEven
 
 describe( 'WikimediaStream tests', () => {
 
-	beforeEach( ( doneFn ) => {
-		setTimeout( doneFn, 2000 );
-	} );
-
 	test( 'start stream from canonical ID (mediawiki.recentchange)', () => {
 		return new Promise<void>( ( res, rej ) => {
 			const stream = new WikimediaStream( 'mediawiki.recentchange' );


### PR DESCRIPTION
Gets rid of some assumptions that plagued integration tests from passing. Writeup for this will be found at [wikitech:User:Chlod Alejandro/Tips for EventStreams consumers](https://wikitech.wikimedia.org/wiki/User:Chlod_Alejandro/Tips_for_EventStreams_consumers), whenever I'm done with this.