### PR TITLE
Support canary events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.1.0
+* Added option to avoid filtering out canary events: `enableCanary`.
+
+# 2.0.1
+* Fixed `package.json` main field to point to the correct file.
+
 # 2.0.0
 * **BREAKING CHANGE:** `mediawiki.revision-score` has been removed following its deprecation ([phab:T342116](https://phabricator.wikimedia.org/T342116))
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ const stream2 = new WikimediaStream( 'recentchange', {
 When re-opening a previously closed stream, the library will automatically resume
 from the last event that it processed. To avoid this, instantiate a new `WikimediaStream`.
 
+## Canary events
+[Canary events](https://wikitech.wikimedia.org/wiki/Event_Platform/EventStreams#Canary_Events)
+are events that are sent to ensure that the stream is still active. These events are filtered
+out by wikimedia-streams by default. To enable them, set the `enableCanary` option to `true`.
+Note that you will be required to filter out these events yourself, or process them accordingly.
+
+```ts
+
 ## License
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Filter out canary (heartbeat) events by default by checking if `meta.domain == "canary"`, per Data Engineering and Event Platform Team at [T266798](https://phabricator.wikimedia.org/T266798). Canary events can be re-enabled by passing `enableCanary` when creating the stream.

Will be released as 2.1.0 when finished.

**To-do:**
* [x] Add option to re-enable
* [x] Document canary event behavior
* [x] ~~Utilize canary events as part of tests~~
 * Not-so-possible since canary events are only fired once every hour; much longer than the CI timeout.